### PR TITLE
fix spelling mistake 'pakcetOffset'

### DIFF
--- a/src/misc/dummy_data_producer.py
+++ b/src/misc/dummy_data_producer.py
@@ -170,7 +170,7 @@ if __name__ == '__main__':
 
 		args.dropped_packets = []
 		for packetOffset, length in zip(tempPackets, counts):
-			args.dropped_packets += list(range(packetOffset, pakcetOffset + length))
+			args.dropped_packets += list(range(packetOffset, packetOffset + length))
 
 	assert(args.bits in [4, 8, 16])
 	assert(args.clock in [160, 200])


### PR DESCRIPTION
Hi David,
I found this spelling mistake in your python routine to produce dummy data.
cheers,
Michael
<michael.olberg@chalmers.se>